### PR TITLE
Update 3.5 Blender

### DIFF
--- a/Codigo-Fonte/main.py
+++ b/Codigo-Fonte/main.py
@@ -684,9 +684,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
              
@@ -717,9 +717,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
         
@@ -750,9 +750,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
          
@@ -783,9 +783,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
 
@@ -873,9 +873,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             bpy.ops.object.mode_set(mode = 'EDIT')
             
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -963,9 +963,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -997,9 +997,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
              
@@ -1030,9 +1030,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
         
@@ -1063,9 +1063,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
          
@@ -1096,9 +1096,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
 
@@ -1186,9 +1186,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             bpy.ops.object.mode_set(mode = 'EDIT')
             
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -1276,9 +1276,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             bpy.ops.object.mode_set(mode = 'EDIT')
 
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -1311,9 +1311,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
              
@@ -1344,9 +1344,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
         
@@ -1377,9 +1377,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
          
@@ -1410,9 +1410,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
 
@@ -1500,9 +1500,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
 
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -1590,9 +1590,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
 
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -1625,9 +1625,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
              
@@ -1658,9 +1658,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
         
@@ -1691,9 +1691,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
          
@@ -1724,9 +1724,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
 
@@ -1814,9 +1814,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -1905,9 +1905,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
 
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, vertex_only=False, profile=insideDegree)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
             
     ## Deselecting everything:
     bpy.ops.object.mode_set(mode = 'EDIT')

--- a/Codigo-Fonte/main.py
+++ b/Codigo-Fonte/main.py
@@ -158,8 +158,10 @@ def create3DMass(label, width, depth, height):
     # Creating primitive object:
     bpy.ops.mesh.primitive_cube_add()
     
+    name = "Cube" if bpy.context.preferences.view.language == "en_US" else "Cubo"
+    
     # Selecting created object:
-    bpy.data.objects["Cube"].select_set(True)
+    bpy.data.objects[name].select_set(True)
     
     # Storing reference to object:
     mass = bpy.context.selected_objects[0]

--- a/Codigo-Fonte/main.py
+++ b/Codigo-Fonte/main.py
@@ -684,9 +684,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
              
@@ -717,9 +717,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
         
@@ -750,9 +750,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
          
@@ -783,9 +783,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
 
@@ -873,9 +873,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             bpy.ops.object.mode_set(mode = 'EDIT')
             
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -963,9 +963,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -997,9 +997,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
              
@@ -1030,9 +1030,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
         
@@ -1063,9 +1063,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
          
@@ -1096,9 +1096,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
 
@@ -1186,9 +1186,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             bpy.ops.object.mode_set(mode = 'EDIT')
             
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -1276,9 +1276,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             bpy.ops.object.mode_set(mode = 'EDIT')
 
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -1311,9 +1311,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
              
@@ -1344,9 +1344,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
         
@@ -1377,9 +1377,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
          
@@ -1410,9 +1410,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
 
@@ -1500,9 +1500,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
 
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -1590,9 +1590,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
 
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -1625,9 +1625,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
              
@@ -1658,9 +1658,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
         
@@ -1691,9 +1691,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
          
@@ -1724,9 +1724,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
 
@@ -1814,9 +1814,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
             
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
             bpy.ops.object.mode_set(mode = 'OBJECT')
             
@@ -1905,9 +1905,9 @@ def roundShape(object, type, direction, roundingDegree, segments, sideReference,
 
             # Applying specific deformation:
             if direction == "outside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, clamp_overlap=True)
             elif direction == "inside":
-                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, affect="EDGES", profile=insideDegree, clamp_overlap=True)
+                bpy.ops.mesh.bevel(offset=roundingDegree, offset_pct=0, segments=segments, profile=insideDegree, clamp_overlap=True)
             
     ## Deselecting everything:
     bpy.ops.object.mode_set(mode = 'EDIT')

--- a/Codigo-Fonte/main.py
+++ b/Codigo-Fonte/main.py
@@ -22,6 +22,8 @@ HIDE_VIRTUAL_SHAPES = True
 REMOVE_VIRTUAL_SHAPES = False
 
 
+bpy.ops.mesh.primitive_cube_add(enter_editmode=False, align='WORLD', location=(0, 0, 0), scale=(1, 1, 1))
+
 ########################################################################################################
 # $ CLASSES MODULE
 ########################################################################################################


### PR DESCRIPTION
Olá!

Fiz algumas alterações na implementação, para permitir que o código seja executado no blender em versões acima da 2.8 e outras poucas adições. Sendo elas:

- Cria um cubo quando inicia a execução. Isso ajuda em casos onde não existe nenhum objeto no cenário, evitando assim erros de execução;
- Adiciona validação da linguagem (inglês ou português) ao selecionar o cubo criado anteriormente, que representa a base para a criação da construção;
- Remove o parâmetro "vertex_only". Nas versões 2.8 e posteriores do Blender, o parâmetro "vertex_only" foi removido do método "bpy.ops.mesh.bevel". 
- Adiciona parâmetro "clamp_overlap". Ele é utilizado para evitar que faces adjacentes se sobreponham com a aplicação do bevel.